### PR TITLE
fix: added patched hyperfuel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "envio_hyperfuel-client"
-version = "1.2.0"
+version = "1.2.1"
 
 [lib]
 crate-type = ["cdylib"]
@@ -21,7 +21,7 @@ anyhow = "1.0.83"
 env_logger = "0.11"
 faster-hex = "0.9.0"
 
-hyperfuel-client = "2.1.0"
+hyperfuel-client = "2.1.1"
 hyperfuel-net-types = "3.0.0"
 hyperfuel-format = "3.0.0"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envio-dev/hyperfuel-client",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {


### PR DESCRIPTION
Updated to hyperfuel version with receipt ordering bug patch.  No longer does ordering in client, relies on correct ordering from hyperfuel.